### PR TITLE
feat: add X/Twitter post embedding in markdown

### DIFF
--- a/src/components/MarkdownRenderer/index.tsx
+++ b/src/components/MarkdownRenderer/index.tsx
@@ -55,10 +55,11 @@ const MarkdownRenderer: React.FC<Props> = ({ content }) => {
       return <YouTubeEmbed videoId={videoId} />;
     }
 
-    // Check if it's an X/Twitter link
+    // Check if it's an X/Twitter embed (only for auto-generated links from bare URLs)
     const tweetMatch = href.match(/(?:twitter\.com|x\.com)\/\w+\/status\/(\d+)/);
+    const childText = typeof children === 'string' ? children : Array.isArray(children) ? children[0] : '';
 
-    if (tweetMatch) {
+    if (tweetMatch && childText === 'Tweet') {
       const tweetId = tweetMatch[1];
       return <TweetEmbed tweetId={tweetId} />;
     }

--- a/src/components/MarkdownRenderer/index.tsx
+++ b/src/components/MarkdownRenderer/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react"
 import ReactMarkdown from "react-markdown"
 import styled from "@emotion/styled"
+import { useTheme } from "@emotion/react"
 
 // Preprocess content to handle Obsidian images, YouTube URLs, and X/Twitter URLs
 const preprocessMarkdown = (content: string): string => {
@@ -96,6 +97,8 @@ const YouTubeEmbed: React.FC<{ videoId: string }> = ({ videoId }) => (
 
 const TweetEmbed: React.FC<{ tweetId: string }> = ({ tweetId }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const theme = useTheme() as any;
+  const twitterTheme = theme?.scheme === 'light' ? 'light' : 'dark';
 
   useEffect(() => {
     const renderTweet = () => {
@@ -104,6 +107,7 @@ const TweetEmbed: React.FC<{ tweetId: string }> = ({ tweetId }) => {
         (window as any).twttr.widgets.createTweet(tweetId, containerRef.current, {
           align: 'center',
           conversation: 'none',
+          theme: twitterTheme,
         });
       }
     };
@@ -117,7 +121,7 @@ const TweetEmbed: React.FC<{ tweetId: string }> = ({ tweetId }) => {
       script.onload = renderTweet;
       document.body.appendChild(script);
     }
-  }, [tweetId]);
+  }, [tweetId, twitterTheme]);
 
   return (
     <div style={{ margin: '2rem 0', display: 'flex', justifyContent: 'center' }}>

--- a/src/components/MarkdownRenderer/index.tsx
+++ b/src/components/MarkdownRenderer/index.tsx
@@ -1,8 +1,8 @@
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import ReactMarkdown from "react-markdown"
 import styled from "@emotion/styled"
 
-// Preprocess content to handle Obsidian images and YouTube URLs
+// Preprocess content to handle Obsidian images, YouTube URLs, and X/Twitter URLs
 const preprocessMarkdown = (content: string): string => {
   // Convert ![[image.webp]] to ![image](/api/image/image.webp)
   let processed = content.replace(/!\[\[([^\]]+)\]\]/g, (match, filename) => {
@@ -22,6 +22,14 @@ const preprocessMarkdown = (content: string): string => {
   processed = processed.replace(/(?<![\[\(])https:\/\/(?:www\.)?youtu(?:\.be\/|be\.com\/watch\?v=)([a-zA-Z0-9_-]{11})(?![\]\)])/g, 
     (match, videoId) => {
       return `[YouTube Video](https://www.youtube.com/watch?v=${videoId})`;
+    }
+  );
+
+  // Convert bare X/Twitter URLs to markdown links
+  // Match https://twitter.com/user/status/ID and https://x.com/user/status/ID
+  processed = processed.replace(/(?<![\[\(])https:\/\/(?:twitter\.com|x\.com)\/\w+\/status\/(\d+)[^\s)]*(?![\]\)])/g,
+    (match, tweetId) => {
+      return `[Tweet](https://x.com/i/status/${tweetId})`;
     }
   );
 
@@ -45,6 +53,14 @@ const MarkdownRenderer: React.FC<Props> = ({ content }) => {
     if (youtubeMatch) {
       const videoId = youtubeMatch[1];
       return <YouTubeEmbed videoId={videoId} />;
+    }
+
+    // Check if it's an X/Twitter link
+    const tweetMatch = href.match(/(?:twitter\.com|x\.com)\/\w+\/status\/(\d+)/);
+
+    if (tweetMatch) {
+      const tweetId = tweetMatch[1];
+      return <TweetEmbed tweetId={tweetId} />;
     }
     
     return <a href={href}>{children}</a>;
@@ -76,6 +92,38 @@ const YouTubeEmbed: React.FC<{ videoId: string }> = ({ videoId }) => (
     />
   </div>
 );
+
+const TweetEmbed: React.FC<{ tweetId: string }> = ({ tweetId }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const renderTweet = () => {
+      if (containerRef.current) {
+        containerRef.current.innerHTML = '';
+        (window as any).twttr.widgets.createTweet(tweetId, containerRef.current, {
+          align: 'center',
+          conversation: 'none',
+        });
+      }
+    };
+
+    if ((window as any).twttr?.widgets) {
+      renderTweet();
+    } else {
+      const script = document.createElement('script');
+      script.src = 'https://platform.twitter.com/widgets.js';
+      script.async = true;
+      script.onload = renderTweet;
+      document.body.appendChild(script);
+    }
+  }, [tweetId]);
+
+  return (
+    <div style={{ margin: '2rem 0', display: 'flex', justifyContent: 'center' }}>
+      <div ref={containerRef} style={{ maxWidth: 550, width: '100%' }} />
+    </div>
+  );
+};
 
 export default MarkdownRenderer;
 


### PR DESCRIPTION
## Summary

Adds support for embedding X/Twitter posts in blog markdown, same pattern as the existing YouTube embed.

## How it works

1. **Preprocessing**: Bare X/Twitter URLs get converted to markdown links
   - Supports both `x.com` and `twitter.com` URLs
   - e.g. `https://x.com/user/status/123456` → embedded tweet

2. **Rendering**: The `LinkComponent` detects Twitter links and renders them using Twitter's official `widgets.js` script for native tweet cards

3. **No extra deps needed** — uses Twitter's platform script directly

## Usage

Just paste an X/Twitter URL on its own line in a blog post:

```
Check out this thread:

https://x.com/VitalikButerin/status/1234567890
```

It will render as an embedded tweet card.