### PR TITLE
fix: preserve youtube markdown links

### DIFF
--- a/src/components/MarkdownRenderer/index.tsx
+++ b/src/components/MarkdownRenderer/index.tsx
@@ -37,6 +37,18 @@ const preprocessMarkdown = (content: string): string => {
   return processed;
 };
 
+const getTextContent = (children: React.ReactNode): string => {
+  if (typeof children === "string" || typeof children === "number") {
+    return String(children)
+  }
+
+  if (Array.isArray(children)) {
+    return children.map(getTextContent).join("")
+  }
+
+  return ""
+}
+
 type Props = {
   content: string
 }
@@ -51,14 +63,15 @@ const MarkdownRenderer: React.FC<Props> = ({ content }) => {
     // Check if it's a YouTube link
     const youtubeMatch = href.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
     
-    if (youtubeMatch) {
+    const childText = getTextContent(children);
+
+    if (youtubeMatch && childText === 'YouTube Video') {
       const videoId = youtubeMatch[1];
       return <YouTubeEmbed videoId={videoId} />;
     }
 
     // Check if it's an X/Twitter embed (only for auto-generated links from bare URLs)
     const tweetMatch = href.match(/(?:twitter\.com|x\.com)\/\w+\/status\/(\d+)/);
-    const childText = typeof children === 'string' ? children : Array.isArray(children) ? children[0] : '';
 
     if (tweetMatch && childText === 'Tweet') {
       const tweetId = tweetMatch[1];

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -23,7 +23,7 @@ export const getStaticPaths = async () => {
 
   return {
     paths: filteredPost.map((row) => `/${row.slug}`),
-    fallback: true,
+    fallback: "blocking",
   }
 }
 
@@ -36,7 +36,18 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   const detailPosts = filterPosts(posts, filter)
   const postDetail = detailPosts.find((t: any) => t.slug === slug)
-  const recordMap = await getRecordMap(postDetail?.id!)
+
+  if (!postDetail) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+      revalidate: CONFIG.revalidateTime,
+    }
+  }
+
+  const recordMap = await getRecordMap(postDetail.id)
 
   await queryClient.prefetchQuery(queryKey.post(`${slug}`), () => ({
     ...postDetail,


### PR DESCRIPTION
## Summary
- Only auto-embed YouTube links generated from bare URLs; normal markdown links to YouTube stay as links
- Redirect unknown post slugs back to `/` instead of trying to read a missing markdown file
- Use blocking fallback so bad slugs resolve server-side instead of rendering a broken fallback page

## Test Plan
- [x] `corepack yarn lint`
- [x] `corepack yarn build`
- [x] Local curl: bad slug returns `307 Location: /`
- [x] Local page HTML: markdown YouTube link remains a watch link, no iframe embed
